### PR TITLE
Add Generic Webhook Trigger plugin

### DIFF
--- a/jenkins/JCasC/plugins.txt
+++ b/jenkins/JCasC/plugins.txt
@@ -45,6 +45,7 @@ docker-workflow:1.23
 durable-task:1.34
 external-monitor-job:1.7
 favorite:2.3.2
+generic-webhook-trigger:1.72
 git-client:3.3.0
 git-server:1.9
 git:4.3.0

--- a/jenkins/Jenkins Cluster/gcp/Docker-image/Docker-files/plugins.txt
+++ b/jenkins/Jenkins Cluster/gcp/Docker-image/Docker-files/plugins.txt
@@ -160,3 +160,4 @@ build-timeout
 build-token-trigger
 build-token-root
 xml-job-to-job-dsl:0.1.13
+generic-webhook-trigger:1.72


### PR DESCRIPTION
Add Generic Webhook Trigger plugin (https://plugins.jenkins.io/generic-webhook-trigger/)

Plugin is being added so that a Jenkins job can extract info from the body of a web call

See issue [111](https://github.com/tranquilitybase-io/tb-gcp-dac/issues/111) in dac repo.