### PR TITLE
Issue 544 - Change seed job to only build jobs from master branch

### DIFF
--- a/jenkins/Jenkins Cluster/gcp/Docker-image/Docker-files/jenkins.yaml
+++ b/jenkins/Jenkins Cluster/gcp/Docker-image/Docker-files/jenkins.yaml
@@ -52,7 +52,7 @@ jobs:
     job('Seed All') {
       parameters {
         stringParam('REPO', 'https://github.com/tranquilitybase-io/tb-jenkins-jobs.git', 'The branch where Jenkins is stored')
-        stringParam('BRANCH', 'master', 'The branch (used for testing)')
+        stringParam('BRANCH', 'main', 'The branch (used for testing)')
       }
       triggers {
         cron("H/15 * * * *")

--- a/jenkins/Jenkins Cluster/gcp/Docker-image/Docker-files/jenkins.yaml
+++ b/jenkins/Jenkins Cluster/gcp/Docker-image/Docker-files/jenkins.yaml
@@ -61,6 +61,7 @@ jobs:
         git {
           remote {
             url '$REPO'
+            branch '$BRANCH'
           }
         }
       }


### PR DESCRIPTION
Seed job has been modified to only populate jobs that have been pushed to the master branch of the Jenkins-Jobs repo.