### PR TITLE
Issue 10 - Install Docker engine as part of Jenkins Image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,14 @@ RUN curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}
   && gpg --verify /sbin/tini.asc \
   && rm -rf /sbin/tini.asc /root/.gnupg \
   && chmod +x /sbin/tini
+  
+# Installs Docker Engine  
+RUN sudo apt-get update \
+&& sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common \
+&& curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - \ 
+&& sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+&& sudo apt-get update \
+&& sudo apt-get install -y docker-ce docker-ce-cli containerd.io  
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}
 # Installs Docker Engine  
 RUN sudo apt-get update \
 && sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common \
-&& curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - \ 
+&& curl -4fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - \ 
 && sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
 && sudo apt-get update \
 && sudo apt-get install -y docker-ce docker-ce-cli containerd.io  


### PR DESCRIPTION
This PR installs the docker engine as part of the Jenkins image build.

To test if the container had the Docker engine installed correctly, I ran a deployment that deployed the jenkins image with these latest changes.

After logging into the container I ran the following two commands "which docker" and "docker -v" to see if docker was installed correctly.

The following screenshot below shows the result of running the above commands to show that docker was installed sucessfully.

![Screenshot (48)](https://user-images.githubusercontent.com/64900858/100114985-e72f1b80-2e69-11eb-937c-52c961f660ff.png)
 