### PR TITLE
Issue 3 - Ensure the Jenkins container can deploy from a Google Source Repository git repo

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -28,7 +28,7 @@ credentials:
           scope: GLOBAL
           username: "TBservice-jenkins"
       - googleRobotPrivateKey:
-          projectId: "shared-ec-bd6ifagj"
+          projectId: "${GCR_ID}"
           serviceAccountConfig:
             json:
               filename: "ec-service-account-config.json"

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -27,6 +27,12 @@ credentials:
           password: "Jn5u9y8UI*M*"
           scope: GLOBAL
           username: "TBservice-jenkins"
+      - googleRobotPrivateKey:
+          projectId: "shared-ec-bd6ifagj"
+          serviceAccountConfig:
+            json:
+              filename: "ec-service-account-config.json"
+              secretJsonKey: "${base64:${readFile:${GOOGLE_APPLICATION_CREDENTIALS}}"
 unclassified:
   gitSCM:
     createAccountBasedOnEmail: true

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -32,7 +32,7 @@ credentials:
           serviceAccountConfig:
             json:
               filename: "ec-service-account-config.json"
-              secretJsonKey: "${base64:${readFile:${GOOGLE_APPLICATION_CREDENTIALS}}"
+              secretJsonKey: ${base64:${readFile:${GOOGLE_APPLICATION_CREDENTIALS}}}
 unclassified:
   gitSCM:
     createAccountBasedOnEmail: true


### PR DESCRIPTION
Creation of Google Private Key along with setting the appropriate folder that will host the gcr repos have been implemented in the Jenkins Casc 